### PR TITLE
allow android build.gradle defaultConfig overrides

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,12 +1,20 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
+def DEFAULT_COMPILE_SDK_VERSION = 30
+def DEFAULT_MIN_SDK_VERSION = 23
+def DEFAULT_TARGET_SDK_VERSION = 28
+
+def safeExtGet(prop, fallback) {
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 android {
-    compileSdkVersion 30
+    compileSdkVersion safeExtGet('compileSdkVersion', DEFAULT_COMPILE_SDK_VERSION)
 
     defaultConfig {
-        minSdkVersion 23
-        targetSdkVersion 28
+        minSdkVersion safeExtGet('minSdkVersion', DEFAULT_MIN_SDK_VERSION)
+        targetSdkVersion safeExtGet('targetSdkVersion', DEFAULT_TARGET_SDK_VERSION)
         versionCode 1
         versionName "1.0"
         ndk {


### PR DESCRIPTION
This package defaultConfig properties are not inline with react native, for instance latest react native minSdkVersion is 21.
So instead of forcing developers to use tools:overrideLibrary in their manifest file we can use root project ext properties like kotlin_version is already used.